### PR TITLE
Use archived 2018 repository

### DIFF
--- a/texlive/Dockerfile
+++ b/texlive/Dockerfile
@@ -15,5 +15,7 @@ RUN wget ftp://tug.org/historic/systems/texlive/2018/install-tl-unx.tar.gz \
     && ./install-tl --profile texlive.profile
 
 ENV PATH="/usr/local/texlive/2018/bin/x86_64-linuxmusl:${PATH}"
+# Since we downloaded 2018, fix the repository version also on 2018
+RUN tlmgr option repository http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2018/tlnet-final/
 RUN tlmgr update --self
 RUN tlmgr install latexmk


### PR DESCRIPTION
This fixes the tlmgr package repo at 2018 so at least it works again. Will think about a new image for texlive 2019.

Note that this has already been uploaded to https://hub.docker.com/r/phpirates/tex and is already in use.